### PR TITLE
横書きプレビューの折り返し修正とデプロイのshrine-clicker除外

### DIFF
--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -132,7 +132,10 @@ jobs:
           echo "   - 増分転送（変更されたファイルのみ）"
           echo "   - 古いファイルは自動削除（--delete）"
 
-          rsync -avz --delete \
+          # shrine-clicker is an unrelated app living in the same deploy path,
+          # owned by another user. Exclude it so --delete doesn't try (and fail)
+          # to remove it, which otherwise fails the whole deploy with code 23.
+          rsync -avz --delete --exclude='shrine-clicker' \
             -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             dist/ \
             $EC2_USER@$EC2_HOST:$DEPLOY_PATH/ 2>&1 || {

--- a/src/index.css
+++ b/src/index.css
@@ -123,3 +123,24 @@ ruby rt {
   scrollbar-width: auto;
   scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.05);
 }
+
+/* Horizontal preview: keep content within the device width by wrapping, rather
+   than overflowing off-screen where it can't be scrolled to (the horizontal
+   container hides overflow-x). Scoped to horizontal-tb so vertical writing —
+   which is meant to scroll horizontally — is left untouched. */
+.preview-container [style*="horizontal-tb"] {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.preview-container [style*="horizontal-tb"] pre {
+  white-space: pre-wrap;
+}
+
+.preview-container [style*="horizontal-tb"] pre,
+.preview-container [style*="horizontal-tb"] code,
+.preview-container [style*="horizontal-tb"] img,
+.preview-container [style*="horizontal-tb"] table {
+  max-width: 100%;
+}
+


### PR DESCRIPTION
## 概要

横書きプレビューの折り返し不具合の修正と、デプロイを常時グリーンにする調整の2点です。

## 変更内容

### 1. 横書きプレビューでデバイス幅を超える内容を折り返す (`eb4a8f6`)
スマホなど狭い画面で、ビューポート幅を超える内容（長いURL/単語、コードブロック、大きい画像・表）が横書きプレビューで画面外にはみ出していました。横書きコンテナは `overflow-x` を隠すため、はみ出した部分はスクロールして読むこともできませんでした。

- `overflow-wrap: anywhere` / `word-break: break-word` で長い語を折り返し
- `pre` を `white-space: pre-wrap`、`pre/code/img/table` を `max-width: 100%`
- `horizontal-tb`（横書き）にのみ適用。横スクロールが正しい挙動の縦書きには影響させない

### 2. デプロイの rsync から `shrine-clicker` を除外 (`3c302af`)
デプロイ先パスに別ユーザー所有の無関係アプリ `shrine-clicker/` が同居しており、`rsync --delete` がこれを削除できず（Permission denied）、本体ファイルは転送できているのに毎回 exit code 23 でデプロイが失敗（赤）していました。`--exclude='shrine-clicker'` で除外し、デプロイがグリーンで完了するようにします。

## 確認

- `npm run build` 通過、折り返しCSSが出力に含まれることを確認済み
- ②の効果（デプロイがグリーンになること）はマージ後のデプロイ実行で確認できます


---
_Generated by [Claude Code](https://claude.ai/code/session_0161Jgy7LT1Cgc5jKAyqoAjp)_