### PR TITLE
プレビューにタイトル/本文コピーボタンを追加（本文はなろう記法へ変換）

### DIFF
--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -8,6 +8,7 @@ import { SettingsPanel } from './SettingsPanel';
 import { MobileToolbar } from './MobileToolbar';
 import { FloatingToolbar } from './FloatingToolbar';
 import { renderRubyAndBouten } from '../../utils/markdownRenderer';
+import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface MarkdownEditorProps {
   value: string;
@@ -19,16 +20,30 @@ interface MarkdownEditorProps {
   onNextFile?: () => void;
   prevFileName?: string;
   nextFileName?: string;
+  // Episode title (≒ file name) used by the "copy title" button in preview.
+  title?: string;
 }
 
-export const MarkdownEditor = ({ value, onChange, onSave, onPrevFile, onNextFile, prevFileName, nextFileName }: MarkdownEditorProps) => {
+export const MarkdownEditor = ({ value, onChange, onSave, onPrevFile, onNextFile, prevFileName, nextFileName, title }: MarkdownEditorProps) => {
   const [showPreview, setShowPreview] = useState(false);
   const [previewHtml, setPreviewHtml] = useState('');
   const [showSettings, setShowSettings] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const [hasSelection, setHasSelection] = useState(false);
+  // Which copy button last succeeded, for transient "コピーしました" feedback.
+  const [copied, setCopied] = useState<'title' | 'body' | null>(null);
   const editorRef = useRef<any>(null);
   const previewRef = useRef<HTMLDivElement>(null);
+
+  const handleCopy = async (kind: 'title' | 'body', text: string) => {
+    const ok = await copyTextToClipboard(text);
+    if (ok) {
+      setCopied(kind);
+      setTimeout(() => setCopied((c) => (c === kind ? null : c)), 1500);
+    } else {
+      alert('コピーに失敗しました');
+    }
+  };
 
   const {
     fontFamily,
@@ -235,6 +250,37 @@ export const MarkdownEditor = ({ value, onChange, onSave, onPrevFile, onNextFile
               </span>
             )}
           </div>
+
+          {/* Copy buttons (only in preview) — title ≒ file name, and the body
+              as plain text with line breaks, for pasting into novel sites. */}
+          {showPreview && (
+            <>
+              <button
+                onClick={() => handleCopy('title', title || '')}
+                disabled={!title}
+                className="flex items-center gap-1 px-2 py-1 text-xs sm:text-sm font-medium rounded transition flex-shrink-0 text-gray-700 hover:bg-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
+                title="タイトル（ファイル名）をコピー"
+                aria-label="タイトルをコピー"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                <span className="whitespace-nowrap">{copied === 'title' ? 'コピー✓' : 'タイトル'}</span>
+              </button>
+              <button
+                onClick={() => handleCopy('body', value)}
+                className="flex items-center gap-1 px-2 py-1 text-xs sm:text-sm font-medium rounded transition flex-shrink-0 text-gray-700 hover:bg-gray-200"
+                title="本文をプレーンテキスト（改行あり）でコピー"
+                aria-label="本文をコピー"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                <span className="whitespace-nowrap">{copied === 'body' ? 'コピー✓' : '本文'}</span>
+              </button>
+              <div className="hidden sm:block w-px h-4 bg-gray-300 mx-1" />
+            </>
+          )}
 
           {/* Settings Button */}
           <button

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -7,7 +7,7 @@ import { useEditorSettingsStore, FONT_CONFIG, BACKGROUND_CONFIG } from '../../st
 import { SettingsPanel } from './SettingsPanel';
 import { MobileToolbar } from './MobileToolbar';
 import { FloatingToolbar } from './FloatingToolbar';
-import { renderRubyAndBouten } from '../../utils/markdownRenderer';
+import { renderRubyAndBouten, toNarouFormat } from '../../utils/markdownRenderer';
 import { copyTextToClipboard } from '../../utils/clipboard';
 
 interface MarkdownEditorProps {
@@ -268,9 +268,9 @@ export const MarkdownEditor = ({ value, onChange, onSave, onPrevFile, onNextFile
                 <span className="whitespace-nowrap">{copied === 'title' ? 'コピー✓' : 'タイトル'}</span>
               </button>
               <button
-                onClick={() => handleCopy('body', value)}
+                onClick={() => handleCopy('body', toNarouFormat(value))}
                 className="flex items-center gap-1 px-2 py-1 text-xs sm:text-sm font-medium rounded transition flex-shrink-0 text-gray-700 hover:bg-gray-200"
-                title="本文をプレーンテキスト（改行あり）でコピー"
+                title="本文をなろう記法（改行あり）でコピー"
                 aria-label="本文をコピー"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -445,6 +445,7 @@ export const EditorPage = () => {
               onNextFile={nextFile ? () => handleFileSelect(nextFile) : undefined}
               prevFileName={prevFile?.path.split('/').pop()}
               nextFileName={nextFile?.path.split('/').pop()}
+              title={(currentFile.path.split('/').pop() || '').replace(/\.(md|markdown)$/i, '')}
             />
           ) : (
             <div className="h-full flex items-center justify-center text-gray-500 p-4">

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Copy text to the clipboard, with a fallback for non-secure (http) contexts.
+ *
+ * The app is served over plain http on EC2, where `navigator.clipboard` is
+ * unavailable (it requires a secure context). Fall back to a temporary
+ * textarea + execCommand('copy'), which still works there.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy approach below.
+    }
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    // Keep it out of view and avoid scrolling/zoom jumps on mobile.
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    textarea.setAttribute('readonly', '');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/markdownRenderer.ts
+++ b/src/utils/markdownRenderer.ts
@@ -53,6 +53,35 @@ export function renderRubyAndBouten(html: string): string {
 }
 
 /**
+ * Convert the editor's ruby/bouten notation to 小説家になろう (Narou) format,
+ * for pasting an episode body into Narou.
+ *
+ * - Ruby:   親文字《ふりがな》 -> ｜親文字《ふりがな》  (explicit full-width pipe so
+ *           kana-containing base text isn't mis-detected on Narou)
+ * - Bouten: 親文字《・・》     -> 《《親文字》》          (Narou emphasis-dots)
+ *
+ * Bouten is handled before ruby (mirroring renderRubyAndBouten) so the dot
+ * marker 《・・》 isn't mistaken for a ruby reading.
+ */
+export function toNarouFormat(text: string): string {
+  // Bouten: base text followed by 《・...》 -> 《《base》》
+  let out = text.replace(
+    /([一-龠々〆ヵヶぁ-んァ-ヶーa-zA-Z0-9]+)《(・+)》/g,
+    (_match, baseText) => `《《${baseText}》》`
+  );
+
+  // Ruby: base text + 《reading》 -> ｜base《reading》. The lookbehind keeps the
+  // match starting at the head of a run, so an already-piped ｜base《》 is left
+  // alone and the pipe isn't inserted mid-run.
+  out = out.replace(
+    /(?<![｜一-龠々〆ヵヶぁ-んァ-ヶー])([一-龠々〆ヵヶぁ-んァ-ヶー]+)《([^》]+)》/g,
+    (_match, baseText, rubyText) => `｜${baseText}《${rubyText}》`
+  );
+
+  return out;
+}
+
+/**
  * Strip ruby and bouten notation for plain text
  * Useful for character counting without markup
  */


### PR DESCRIPTION
## 概要

小説サイト（主に小説家になろう）へ投稿する際、エピソードのタイトルと本文をそれぞれコピペする作業を支援するため、プレビューにコピーボタンを追加します。

## 変更内容

### 1. プレビューにタイトル/本文コピーボタンを追加 (`c9f385e`)
プレビュー時のツールバーに2つのコピーボタンを追加:

| ボタン | コピー内容 |
|---|---|
| タイトル | ファイル名から拡張子（`.md`/`.markdown`）を除いたもの ≒ エピソードタイトル |
| 本文 | 書いた本文（改行を保持） |

- 押すと一瞬「コピー✓」に変わるフィードバック付き
- デプロイ先が `http://`（非セキュアコンテキスト）で `navigator.clipboard` が使えないため、`execCommand` フォールバックを実装

### 2. 本文コピーをなろう記法へ変換 (`2927419`)
本文ボタンは、エディタ記法をなろう記法へ変換してコピーします:

- ルビ: `颯爽《さっそう》` → `｜颯爽《さっそう》`
- 圏点: `重要《・・》` → `《《重要》》`

変換はプレビューの親文字判定と同じルールに揃えており、すでに `｜` 付きの本文は二重付与しないよう lookbehind でガードしています。

## 既知の注意点

ルビの親文字は「《》直前の漢字・かなの連なり全体」に掛かります（プレビュー表示と一致）。なろうのネイティブ自動ルビ（漢字のみ）とは差が出る場合があるため、実エピソードでの確認を推奨します。漢字のみに限定したい場合はプレビュー/コピー双方の判定変更で対応可能です。

## 確認

- `npx tsc -b --noEmit` / `npm run build` 通過
- なろう変換ロジックは代表ケース（ルビ・圏点・複数ルビ・既存パイプ・地の文）で出力を確認済み


---
_Generated by [Claude Code](https://claude.ai/code/session_0161Jgy7LT1Cgc5jKAyqoAjp)_